### PR TITLE
Fix runtime dependency on constructor name issue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 node_modules/
+.vscode/
 .idea/
 .env
 esm/

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@defisaver/sdk",
-  "version": "1.1.6",
+  "version": "1.1.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@defisaver/sdk",
-      "version": "1.1.6",
+      "version": "1.1.7",
       "license": "ISC",
       "dependencies": {
         "@defisaver/eslint-config": "^1.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@defisaver/sdk",
-  "version": "1.1.3",
+  "version": "1.1.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@defisaver/sdk",
-      "version": "1.1.3",
+      "version": "1.1.6",
       "license": "ISC",
       "dependencies": {
         "@defisaver/eslint-config": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@defisaver/sdk",
-  "version": "1.1.6",
+  "version": "1.1.7",
   "description": "",
   "main": "./umd/index.js",
   "module": "./esm/src/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@defisaver/sdk",
-  "version": "1.1.5",
+  "version": "1.1.6",
   "description": "",
   "main": "./umd/index.js",
   "module": "./esm/src/index.js",

--- a/src/actions/flashloan/AaveV2FlashLoanAction.ts
+++ b/src/actions/flashloan/AaveV2FlashLoanAction.ts
@@ -1,13 +1,16 @@
 import { Action } from '../../Action';
 import { getAddr } from '../../addresses';
 import { EthAddress, uint256, bytes } from '../../types';
+import { FlashLoanId } from './FlashLoanId';
 
 /**
  * Gets a flashloan from Aave v2
  *
  * @category Flashloans
  */
-export class AaveV2FlashLoanAction extends Action {
+export class AaveV2FlashLoanAction extends Action implements FlashLoanId {
+  public flashLoanId = 1;
+
   /**
    * @param loanAmounts
    * @param tokens
@@ -16,7 +19,7 @@ export class AaveV2FlashLoanAction extends Action {
    * @param flParamGetterAddr
    * @param flParamGetterData
    */
-  constructor(tokens:Array<EthAddress>, loanAmounts:Array<uint256>, modes:Array<uint256>, loanPayer:EthAddress, flParamGetterAddr:EthAddress = getAddr('Empty'), flParamGetterData:bytes = []) {
+  constructor(tokens: Array<EthAddress>, loanAmounts: Array<uint256>, modes: Array<uint256>, loanPayer: EthAddress, flParamGetterAddr: EthAddress = getAddr('Empty'), flParamGetterData: bytes = []) {
     super(
       'FLAaveV2',
       getAddr('FLAaveV2'),

--- a/src/actions/flashloan/AaveV3FlashLoanAction.ts
+++ b/src/actions/flashloan/AaveV3FlashLoanAction.ts
@@ -1,13 +1,16 @@
 import { ActionWithL2 } from '../../ActionWithL2';
 import { getAddr } from '../../addresses';
 import { EthAddress, uint256, bytes } from '../../types';
+import { FlashLoanId } from './FlashLoanId';
 
 /**
  * Gets a flashloan from Aave v3 with fee enabled
  *
  * @category Flashloans
  */
-export class AaveV3FlashLoanAction extends ActionWithL2 {
+export class AaveV3FlashLoanAction extends ActionWithL2 implements FlashLoanId {
+  public flashLoanId = 5;
+
   /**
    * @param loanAmounts
    * @param tokens
@@ -16,7 +19,7 @@ export class AaveV3FlashLoanAction extends ActionWithL2 {
    * @param flParamGetterAddr
    * @param flParamGetterData
    */
-  constructor(tokens:Array<EthAddress>, loanAmounts:Array<uint256>, modes:Array<uint256>, loanPayer:EthAddress, flParamGetterAddr:EthAddress = getAddr('Empty'), flParamGetterData:bytes = []) {
+  constructor(tokens: Array<EthAddress>, loanAmounts: Array<uint256>, modes: Array<uint256>, loanPayer: EthAddress, flParamGetterAddr: EthAddress = getAddr('Empty'), flParamGetterData: bytes = []) {
     super(
       'FLAaveV3WithFee',
       getAddr('FLAaveV3'),

--- a/src/actions/flashloan/BalancerFlashLoanAction.ts
+++ b/src/actions/flashloan/BalancerFlashLoanAction.ts
@@ -1,20 +1,23 @@
 import { Action } from '../../Action';
 import { getAddr } from '../../addresses';
 import { EthAddress, uint256, bytes } from '../../types';
+import { FlashLoanId } from './FlashLoanId';
 
 /**
  * Gets a flashloan from Balancer
  *
  * @category Flashloans
  */
-export class BalancerFlashLoanAction extends Action {
+export class BalancerFlashLoanAction extends Action implements FlashLoanId {
+  public flashLoanId = 2;
+
   /**
    * @param tokens
    * @param amounts
    * @param flParamGetterAddr
    * @param flParamGetterData
    */
-  constructor(tokens:Array<EthAddress>, amounts:Array<uint256>, flParamGetterAddr:EthAddress = getAddr('Empty'), flParamGetterData:bytes = []) {
+  constructor(tokens: Array<EthAddress>, amounts: Array<uint256>, flParamGetterAddr: EthAddress = getAddr('Empty'), flParamGetterData: bytes = []) {
     super(
       'FLBalancer',
       getAddr('FLBalancer'),

--- a/src/actions/flashloan/FLAction.ts
+++ b/src/actions/flashloan/FLAction.ts
@@ -1,53 +1,32 @@
 import { Action } from '../../Action';
 import { getAddr } from '../../addresses';
-
+import { FlashLoanId } from './FlashLoanId';
 /**
  * Gets a specific FL action
  *
  * @category Flashloans
  */
+type SpecificFlashLoanAction = Action & FlashLoanId;
+
 export class FLAction extends Action {
   /**
    * @param specificFLAction - FL Action to be used
    */
-  #handleArgs(specificFLAction: Action) {
+  #handleArgs(specificFLAction: SpecificFlashLoanAction) {
     const argsToReturn = [
       specificFLAction.args[0],
       specificFLAction.args[1],
       specificFLAction.args[2],
       specificFLAction.args[3],
       getAddr('Empty'),
-      [],
+      [specificFLAction.flashLoanId],
       specificFLAction.args[6],
     ];
-    if (specificFLAction.constructor.name === 'AaveV2FlashLoanAction') {
-      argsToReturn[5] = [1];
-    }
-    if (specificFLAction.constructor.name === 'BalancerFlashLoanAction') {
-      argsToReturn[5] = [2];
-    }
-    if (specificFLAction.constructor.name === 'GhoFlashLoanAction') {
-      argsToReturn[5] = [3];
-    }
-    if (specificFLAction.constructor.name === 'MakerFlashLoanAction') {
-      argsToReturn[5] = [4];
-    }
-    if (specificFLAction.constructor.name === 'AaveV3FlashLoanAction') {
-      argsToReturn[5] = [5];
-    }
-    if (specificFLAction.constructor.name === 'UniV3FlashLoanAction') {
-      argsToReturn[5] = [6];
-    }
-    if (specificFLAction.constructor.name === 'SparkFlashLoanAction') {
-      argsToReturn[5] = [7];
-    }
-    if (specificFLAction.constructor.name === 'MorphoBlueFlashLoanAction') {
-      argsToReturn[5] = [8];
-    }
+
     return argsToReturn;
   }
 
-  constructor(specificFLAction: Action) {
+  constructor(specificFLAction: SpecificFlashLoanAction) {
     super(
       'FLAction',
       getAddr('FLAction'),
@@ -56,5 +35,6 @@ export class FLAction extends Action {
     );
     this.paramTypes = ['address[]', 'uint256[]', 'uint256[]', 'address', 'address', 'bytes', 'bytes'];
     this.args = this.#handleArgs(specificFLAction);
+    console.log('###ARGS:', this.args);
   }
 }

--- a/src/actions/flashloan/FLAction.ts
+++ b/src/actions/flashloan/FLAction.ts
@@ -35,6 +35,5 @@ export class FLAction extends Action {
     );
     this.paramTypes = ['address[]', 'uint256[]', 'uint256[]', 'address', 'address', 'bytes', 'bytes'];
     this.args = this.#handleArgs(specificFLAction);
-    console.log('###ARGS:', this.args);
   }
 }

--- a/src/actions/flashloan/FlashLoanId.ts
+++ b/src/actions/flashloan/FlashLoanId.ts
@@ -1,0 +1,3 @@
+export interface FlashLoanId {
+  flashLoanId: number;
+}

--- a/src/actions/flashloan/GhoFlashLoanAction.ts
+++ b/src/actions/flashloan/GhoFlashLoanAction.ts
@@ -1,19 +1,22 @@
 import { Action } from '../../Action';
 import { getAddr } from '../../addresses';
 import { EthAddress, uint256, bytes } from '../../types';
+import { FlashLoanId } from './FlashLoanId';
 
 /**
  * Gets a GHO flashloan from GHO Flash Minter
  *
  * @category Flashloans
  */
-export class GhoFlashLoanAction extends Action {
+export class GhoFlashLoanAction extends Action implements FlashLoanId {
+  public flashLoanId = 3;
+
   /**
    * @param amount
    * @param flParamGetterAddr
    * @param flParamGetterData
    */
-  constructor(amount:uint256, flParamGetterAddr:EthAddress = getAddr('Empty'), flParamGetterData:bytes = []) {
+  constructor(amount: uint256, flParamGetterAddr: EthAddress = getAddr('Empty'), flParamGetterData: bytes = []) {
     super(
       'FLGho',
       getAddr('FLGho'),

--- a/src/actions/flashloan/MakerFlashLoanAction.ts
+++ b/src/actions/flashloan/MakerFlashLoanAction.ts
@@ -1,19 +1,22 @@
 import { Action } from '../../Action';
 import { getAddr } from '../../addresses';
 import { EthAddress, uint256, bytes } from '../../types';
+import { FlashLoanId } from './FlashLoanId';
 
 /**
  * Gets a flashloan from Maker
  *
  * @category Flashloans
  */
-export class MakerFlashLoanAction extends Action {
+export class MakerFlashLoanAction extends Action implements FlashLoanId {
+  public flashLoanId = 4;
+
   /**
    * @param amount
    * @param flParamGetterAddr
    * @param flParamGetterData
    */
-  constructor(amount:uint256, flParamGetterAddr:EthAddress = getAddr('Empty'), flParamGetterData:bytes = []) {
+  constructor(amount: uint256, flParamGetterAddr: EthAddress = getAddr('Empty'), flParamGetterData: bytes = []) {
     super(
       'FLMaker',
       getAddr('FLMaker'),

--- a/src/actions/flashloan/MorphoBlueFlashLoanAction.ts
+++ b/src/actions/flashloan/MorphoBlueFlashLoanAction.ts
@@ -1,20 +1,23 @@
 import { Action } from '../../Action';
 import { getAddr } from '../../addresses';
 import { EthAddress, uint256, bytes } from '../../types';
+import { FlashLoanId } from './FlashLoanId';
 
 /**
  * Gets a flashloan from MorphoBlue
  *
  * @category Flashloans
  */
-export class MorphoBlueFlashLoanAction extends Action {
+export class MorphoBlueFlashLoanAction extends Action implements FlashLoanId {
+  public flashLoanId = 8;
+
   /**
    * @param token
    * @param amount
    * @param flParamGetterAddr
    * @param flParamGetterData
    */
-  constructor(token:EthAddress, amount:uint256, flParamGetterAddr:EthAddress = getAddr('Empty'), flParamGetterData:bytes = []) {
+  constructor(token: EthAddress, amount: uint256, flParamGetterAddr: EthAddress = getAddr('Empty'), flParamGetterData: bytes = []) {
     super(
       'FLMorphoBlue',
       getAddr('FLMorphoBlue'),

--- a/src/actions/flashloan/SparkFlashLoanAction.ts
+++ b/src/actions/flashloan/SparkFlashLoanAction.ts
@@ -1,13 +1,16 @@
 import { ActionWithL2 } from '../../ActionWithL2';
 import { getAddr } from '../../addresses';
 import { EthAddress, uint256, bytes } from '../../types';
+import { FlashLoanId } from './FlashLoanId';
 
 /**
  * Gets a flashloan from Spark with fee enabled
  *
  * @category Flashloans
  */
-export class SparkFlashLoanAction extends ActionWithL2 {
+export class SparkFlashLoanAction extends ActionWithL2 implements FlashLoanId {
+  public flashLoanId = 7;
+
   /**
    * @param loanAmounts
    * @param tokens
@@ -16,7 +19,7 @@ export class SparkFlashLoanAction extends ActionWithL2 {
    * @param flParamGetterAddr
    * @param flParamGetterData
    */
-  constructor(tokens:Array<EthAddress>, loanAmounts:Array<uint256>, modes:Array<uint256>, loanPayer:EthAddress, flParamGetterAddr:EthAddress = getAddr('Empty'), flParamGetterData:bytes = []) {
+  constructor(tokens: Array<EthAddress>, loanAmounts: Array<uint256>, modes: Array<uint256>, loanPayer: EthAddress, flParamGetterAddr: EthAddress = getAddr('Empty'), flParamGetterData: bytes = []) {
     super(
       'FLSpark',
       getAddr('FLSpark'),

--- a/src/actions/flashloan/UniV3FlashLoanAction.ts
+++ b/src/actions/flashloan/UniV3FlashLoanAction.ts
@@ -1,13 +1,16 @@
 import { Action } from '../../Action';
 import { getAddr } from '../../addresses';
 import { EthAddress, uint256, bytes } from '../../types';
+import { FlashLoanId } from './FlashLoanId';
 
 /**
  * Gets a flashloan from UniV3 pool
  *
  * @category Flashloans
  */
-export class UniV3FlashLoanAction extends Action {
+export class UniV3FlashLoanAction extends Action implements FlashLoanId {
+  public flashLoanId = 6;
+
   /**
    * @param token0
    * @param token1
@@ -17,7 +20,7 @@ export class UniV3FlashLoanAction extends Action {
    * @param flParamGetterAddr
    * @param flParamGetterData
    */
-  constructor(token0:EthAddress, token1:EthAddress, pool:EthAddress, amount0:uint256, amount1:uint256, flParamGetterAddr:EthAddress = getAddr('Empty'), flParamGetterData:bytes = []) {
+  constructor(token0: EthAddress, token1: EthAddress, pool: EthAddress, amount0: uint256, amount1: uint256, flParamGetterAddr: EthAddress = getAddr('Empty'), flParamGetterData: bytes = []) {
     super(
       'FLUniV3',
       getAddr('FLUniV3'),


### PR DESCRIPTION
Since the names of the function can be changed in runtime of code that consumes the SDK, we don't want to depend on `constructor.name` for identifying specific FL action. Instead, I added a field on SpecificFLActions through interface implementation (optional, tbh, but more explicit in intention).
